### PR TITLE
Fix chroot detection for unmounted partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Recova
 
 Simple Qt-based recovery tool prototype for Linux.
-It detects mounted Linux systems that can be chrooted into and provides
+It detects Linux systems that can be chrooted into by mounting partitions when needed and provides
 common recovery actions.
 
 ## Build
@@ -13,8 +13,8 @@ make
 
 Run the resulting `recova` binary.
 
-When launched, the first page attempts to chroot into each mounted
-filesystem and prints the results in the integrated terminal. Successful
+When launched, the first page attempts to mount each detected filesystem and chroot into it.
+The results are printed in the integrated terminal. Successful
 targets are listed for selection. After selecting a target you can run
 actions such as updating packages, reinstalling GRUB, installing the LTS
 kernel or creating a new administrator account.


### PR DESCRIPTION
## Summary
- mount partitions under `/mnt/recova-*` when no mountpoint exists
- clean up temporary mount after test
- clarify README about automatic mounting for detection

## Testing
- `qmake recova.pro`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_b_68448ee2a120832cb83d4cc1fbb18af4